### PR TITLE
add read-only grafana user

### DIFF
--- a/nasdaq/.gitignore
+++ b/nasdaq/.gitignore
@@ -1,0 +1,1 @@
+db-config/cedar/license.env

--- a/nasdaq/client/Dockerfile
+++ b/nasdaq/client/Dockerfile
@@ -7,8 +7,8 @@ RUN apt-get update && apt-get install -y g++ cmake libpq-dev
 COPY . .
 RUN cmake . -DCMAKE_BUILD_TYPE=Release -B bin && cmake --build bin
 
-ENV DB_CONNECTION_STRING=postgresql://postgres:postgres@cedar:5432/postgres
+ENV DB1_CONNECTION_STRING=postgresql://postgres:postgres@cedar:5432/postgres
 ENV DB2_CONNECTION_STRING=
 
 # Start the client on container start
-CMD ["sh", "-c", "exec ./bin/NasdaqDriver /nasdaq/data/ /data/ \"$DB_CONNECTION_STRING\" \"$DB2_CONNECTION_STRING\""]
+CMD ["sh", "-c", "exec ./bin/NasdaqDriver /nasdaq/data/ /data/ \"$DB1_CONNECTION_STRING\" \"$DB2_CONNECTION_STRING\""]

--- a/nasdaq/client/NasdaqClient.cpp
+++ b/nasdaq/client/NasdaqClient.cpp
@@ -3,9 +3,12 @@
 
 #include <cassert>
 #include <chrono>
+#include <format>
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include <stdexcept>
+#include <string>
 #include <string_view>
 
 static void noticeProcessor(void* /*arg*/, const char* /*message*/) {}
@@ -23,6 +26,29 @@ void NasdaqClient::connect(std::string_view connectionString) {
 void NasdaqClient::createSchema(std::string_view schemaPath) const {
    loadFile(std::string(schemaPath));
    std::cout << "[" << PQhost(conn) << "] Nasdaq schema created." << std::endl;
+}
+
+void NasdaqClient::grantPermissions(std::string_view grafanaUser) const {
+   assert(conn);
+
+   const char* connectionUser = PQuser(conn);
+   if (connectionUser != nullptr && grafanaUser == connectionUser) {
+      std::cout << "[" << PQhost(conn) << "] Nasdaq permissions skipped for current user." << std::endl;
+      return;
+   }
+
+   char* quotedUser = PQescapeIdentifier(conn, grafanaUser.data(), grafanaUser.size());
+   if (quotedUser == nullptr)
+      throw std::runtime_error("could not escape grafana user");
+
+   std::string command = std::format(
+      "GRANT USAGE ON schema public TO {}; GRANT SELECT ON ALL TABLES IN schema public TO {};",
+      quotedUser,
+      quotedUser);
+   PQfreemem(quotedUser);
+
+   exec(conn, command);
+   std::cout << "[" << PQhost(conn) << "] Nasdaq permissions created." << std::endl;
 }
 
 void NasdaqClient::loadStaticData(std::string_view stocksPath, std::string_view marketMakerPath) const {

--- a/nasdaq/client/NasdaqClient.h
+++ b/nasdaq/client/NasdaqClient.h
@@ -15,6 +15,8 @@ class NasdaqClient {
 
    void createSchema(std::string_view schemaPath) const;
 
+   void grantPermissions(std::string_view grafanaUser) const;
+
    void loadStaticData(std::string_view stocksPath, std::string_view marketMakerPath) const;
 
    void loadPremarketData(std::string_view ordersPath, std::string_view executionsPath, std::string_view cancellationsPath) const;

--- a/nasdaq/client/main.cpp
+++ b/nasdaq/client/main.cpp
@@ -1,7 +1,9 @@
 #include "NasdaqClient.h"
 #include <chrono>
+#include <cstdlib>
 #include <iostream>
 #include <memory>
+#include <string>
 #include <string_view>
 #include <thread>
 
@@ -26,6 +28,8 @@ int main(int argc, char* argv[]) {
    std::string sqlPath = "./";
    std::string dataPath = argv[1];
    std::string serverDataPath = argv[2];
+   const char* envUser = std::getenv("GRAFANA_USER");
+   const std::string grafanaUser = (envUser != nullptr && envUser[0] != '\0') ? envUser : "grafana";
 
    // 1. Create the schema before loading any data.
    // 2. Load static reference tables next.
@@ -33,6 +37,7 @@ int main(int argc, char* argv[]) {
    {
       std::jthread schemaThread([&] {
          client.createSchema(sqlPath + "schema.sql");
+         client.grantPermissions(grafanaUser);
          client.loadStaticData(serverDataPath + "stocks.csv", serverDataPath + "marketMakers.csv");
          client.loadPremarketData(
             serverDataPath + "ordersPreMarket.csv",
@@ -42,6 +47,7 @@ int main(int argc, char* argv[]) {
       std::jthread schemaThread2([&] {
          if (client2) {
             client2->createSchema(sqlPath + "schema.sql");
+            client2->grantPermissions(grafanaUser);
             client2->loadStaticData(serverDataPath + "stocks.csv", serverDataPath + "marketMakers.csv");
             client2->loadPremarketData(
                serverDataPath + "ordersPreMarket.csv",

--- a/nasdaq/client/schema.sql
+++ b/nasdaq/client/schema.sql
@@ -78,3 +78,6 @@ create index on orderbook(orderId);
 create index on cancellations(timestamp);
 create index on executions(timestamp);
 create index on orders(timestamp);
+
+GRANT USAGE ON schema public TO grafana;
+GRANT SELECT ON ALL TABLES IN schema public TO grafana;

--- a/nasdaq/client/schema.sql
+++ b/nasdaq/client/schema.sql
@@ -78,6 +78,3 @@ create index on orderbook(orderId);
 create index on cancellations(timestamp);
 create index on executions(timestamp);
 create index on orders(timestamp);
-
-GRANT USAGE ON schema public TO grafana;
-GRANT SELECT ON ALL TABLES IN schema public TO grafana;

--- a/nasdaq/comparison.compose.yml
+++ b/nasdaq/comparison.compose.yml
@@ -5,9 +5,13 @@ services:
     environment:
       CEDAR_DB: postgres
       CEDAR_USER: postgres
-      CEDAR_PASSWORD: postgres
+      CEDAR_PASSWORD: ${ADMIN_PWD}
+      GRAFANA_USER_PWD: ${GRAFANA_USER_PWD}
+    env_file:
+      - db-config/cedar/license.env
     volumes:
       - data:/data
+      - ./db-config/cedar/user_init.sh:/docker-entrypoint-initdb.d/user_init.sh
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres -d postgres -h 127.0.0.1 -p 5432" ]
       interval: 10s
@@ -19,9 +23,11 @@ services:
     environment:
       POSTGRES_DB: postgres
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_PASSWORD: ${ADMIN_PWD}
+      GRAFANA_USER_PWD: ${GRAFANA_USER_PWD}
     volumes:
       - data:/data
+      - ./db-config/postgres/:/docker-entrypoint-initdb.d/
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres -d postgres -h 127.0.0.1 -p 5432" ]
       interval: 10s
@@ -31,10 +37,11 @@ services:
     image: grafana/grafana:12.0.0
     restart: unless-stopped
     environment:
-      - GF_DASHBOARDS_MIN_REFRESH_INTERVAL=100ms
-      - GF_AUTH_ANONYMOUS_ENABLED=true
-      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
-      - GF_AUTH_DISABLE_LOGIN_FORM=true
+      GRAFANA_USER_PWD: ${GRAFANA_USER_PWD}
+      GF_DASHBOARDS_MIN_REFRESH_INTERVAL: 100ms
+      GF_AUTH_ANONYMOUS_ENABLED: true
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+      GF_AUTH_DISABLE_LOGIN_FORM: true
     ports:
       - 3000:3000
     depends_on:
@@ -59,8 +66,8 @@ services:
       postgres:
         condition: service_healthy
     environment:
-      DB1_CONNECTION_STRING: postgresql://postgres:postgres@cedar:5432/postgres
-      DB2_CONNECTION_STRING: postgresql://postgres:postgres@postgres:5432/postgres
+      DB1_CONNECTION_STRING: postgresql://postgres:${ADMIN_PWD}@cedar:5432/postgres
+      DB2_CONNECTION_STRING: postgresql://postgres:${ADMIN_PWD}@postgres:5432/postgres
     volumes:
       - data:/nasdaq/data
 

--- a/nasdaq/comparison.compose.yml
+++ b/nasdaq/comparison.compose.yml
@@ -8,7 +8,8 @@ services:
       CEDAR_PASSWORD: ${ADMIN_PWD}
       GRAFANA_USER_PWD: ${GRAFANA_USER_PWD}
     env_file:
-      - db-config/cedar/license.env
+      - path: db-config/cedar/license.env
+        required: false
     volumes:
       - data:/data
       - ./db-config/cedar/user_init.sh:/docker-entrypoint-initdb.d/user_init.sh
@@ -37,6 +38,7 @@ services:
     image: grafana/grafana:12.0.0
     restart: unless-stopped
     environment:
+      GRAFANA_USER: ${GRAFANA_USER}
       GRAFANA_USER_PWD: ${GRAFANA_USER_PWD}
       GF_DASHBOARDS_MIN_REFRESH_INTERVAL: 100ms
       GF_AUTH_ANONYMOUS_ENABLED: true
@@ -68,6 +70,7 @@ services:
     environment:
       DB1_CONNECTION_STRING: postgresql://postgres:${ADMIN_PWD}@cedar:5432/postgres
       DB2_CONNECTION_STRING: postgresql://postgres:${ADMIN_PWD}@postgres:5432/postgres
+      GRAFANA_USER: ${GRAFANA_USER}
     volumes:
       - data:/nasdaq/data
 

--- a/nasdaq/compose.yml
+++ b/nasdaq/compose.yml
@@ -6,9 +6,15 @@ services:
     environment:
       CEDAR_DB: postgres
       CEDAR_USER: postgres
-      CEDAR_PASSWORD: postgres
+      CEDAR_PASSWORD: ${ADMIN_PWD}
+      GRAFANA_USER_PWD: ${GRAFANA_USER_PWD}
+    env_file:
+      - db-config/cedar/license.env
+    ports:
+      - 5432:5432
     volumes:
       - data:/data
+      - ./db-config/cedar/user_init.sh:/docker-entrypoint-initdb.d/user_init.sh
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres -d postgres -h 127.0.0.1 -p 5432" ]
       interval: 10s
@@ -19,10 +25,11 @@ services:
     container_name: grafana
     restart: unless-stopped
     environment:
-      - GF_DASHBOARDS_MIN_REFRESH_INTERVAL=100ms
-      - GF_AUTH_ANONYMOUS_ENABLED=true
-      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
-      - GF_AUTH_DISABLE_LOGIN_FORM=true
+      GRAFANA_USER_PWD: ${GRAFANA_USER_PWD}
+      GF_DASHBOARDS_MIN_REFRESH_INTERVAL: 100ms
+      GF_AUTH_ANONYMOUS_ENABLED: true
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+      GF_AUTH_DISABLE_LOGIN_FORM: true
     ports:
       - 3000:3000
     depends_on:
@@ -37,12 +44,12 @@ services:
       cedar:
         condition: service_healthy
     environment:
-      - OPENROUTER_API_KEY={your_api_key_here}
-      - LLM_MODEL=anthropic/claude-sonnet-4.5
-      - DB_HOST=cedar
-      - DB_NAME=postgres
-      - DB_USER=postgres
-      - DB_PASSWORD=postgres
+      OPENROUTER_API_KEY: "{your_api_key_here}"
+      LLM_MODEL: anthropic/claude-sonnet-4.5
+      DB_HOST: cedar
+      DB_NAME: postgres
+      DB_USER: postgres
+      DB_PASSWORD: postgres
     ports:
       - 8080:8080
   parser:
@@ -60,6 +67,8 @@ services:
         condition: service_healthy
       parser:
         condition: service_completed_successfully
+    environment:
+      DB1_CONNECTION_STRING: postgresql://postgres:${ADMIN_PWD}@cedar:5432/postgres
     volumes:
       - data:/nasdaq/data
 

--- a/nasdaq/compose.yml
+++ b/nasdaq/compose.yml
@@ -9,7 +9,8 @@ services:
       CEDAR_PASSWORD: ${ADMIN_PWD}
       GRAFANA_USER_PWD: ${GRAFANA_USER_PWD}
     env_file:
-      - db-config/cedar/license.env
+      - path: db-config/cedar/license.env
+        required: false
     ports:
       - 5432:5432
     volumes:
@@ -25,6 +26,7 @@ services:
     container_name: grafana
     restart: unless-stopped
     environment:
+      GRAFANA_USER: ${GRAFANA_USER}
       GRAFANA_USER_PWD: ${GRAFANA_USER_PWD}
       GF_DASHBOARDS_MIN_REFRESH_INTERVAL: 100ms
       GF_AUTH_ANONYMOUS_ENABLED: true
@@ -69,6 +71,7 @@ services:
         condition: service_completed_successfully
     environment:
       DB1_CONNECTION_STRING: postgresql://postgres:${ADMIN_PWD}@cedar:5432/postgres
+      GRAFANA_USER: ${GRAFANA_USER}
     volumes:
       - data:/nasdaq/data
 

--- a/nasdaq/db-config/cedar/user_init.sh
+++ b/nasdaq/db-config/cedar/user_init.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+echo "CREATE USER grafana WITH PASSWORD '$GRAFANA_USER_PWD';" | process_sql

--- a/nasdaq/db-config/postgres/user-init.sql
+++ b/nasdaq/db-config/postgres/user-init.sql
@@ -1,0 +1,3 @@
+\set app_pwd `echo "$GRAFANA_USER_PWD"` 
+
+CREATE USER grafana WITH PASSWORD :'app_pwd';

--- a/nasdaq/demo.sh
+++ b/nasdaq/demo.sh
@@ -5,6 +5,9 @@ usage() {
     cat <<'EOF'
 Usage: ./demo.sh [--comparison|-c] <start|stop|clean>
 
+Normal mode starts CedarDB, Nasdaq client, Grafana and the AI chat for the demo.
+Comparison mode adds PostgreSQL to the deployment to compare the performance of the two DBs. 
+
 Commands:
   start   Start the demo stack
   stop    Stop the demo stack
@@ -63,10 +66,11 @@ export ADMIN_PWD="${ADMIN_PWD:-evensaferpassword}"
 case "$command" in
     start)
         if [[ ! -s "db-config/cedar/license.env" ]]; then
-            echo "Cedar license missing at db-config/cedar/license.env, falling back to admin user for grafana!" >&2
-            echo "License is required for granting permissions to users." >&2
-            echo "Get your trial license at: console.cedardb.com" >&2
-            echo "" >&2
+            printf '%s\n' \
+                "Cedar license missing at db-config/cedar/license.env, falling back to admin user for grafana!" \
+                "License is required for granting permissions to users." \
+                "Get your trial license at: console.cedardb.com" \
+                "" >&2
 
             export GRAFANA_USER="postgres"
             export GRAFANA_USER_PWD="${ADMIN_PWD}"

--- a/nasdaq/demo.sh
+++ b/nasdaq/demo.sh
@@ -56,14 +56,20 @@ if $comparison; then
     compose_args=(-f comparison.compose.yml)
 fi
 
+export GRAFANA_USER="${GRAFANA_USER:-grafana}"
 export GRAFANA_USER_PWD="${GRAFANA_USER_PWD:-supersafepassword}"
 export ADMIN_PWD="${ADMIN_PWD:-evensaferpassword}"
 
 case "$command" in
     start)
         if [[ ! -s "db-config/cedar/license.env" ]]; then
-            echo "Missing required Cedar license file: db-config/cedar/license.env" >&2
-            exit 1
+            echo "Cedar license missing at db-config/cedar/license.env, falling back to admin user for grafana!" >&2
+            echo "License is required for granting permissions to users." >&2
+            echo "Get your trial license at: console.cedardb.com" >&2
+            echo "" >&2
+
+            export GRAFANA_USER="postgres"
+            export GRAFANA_USER_PWD="${ADMIN_PWD}"
         fi
         docker compose "${compose_args[@]}" up -d --build --force-recreate
         ;;

--- a/nasdaq/demo.sh
+++ b/nasdaq/demo.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: ./demo.sh [--comparison|-c] <start|stop|clean>
+
+Commands:
+  start   Start the demo stack
+  stop    Stop the demo stack
+  clean   Stop the demo stack and remove volumes
+
+Options:
+  -c, --comparison   Use comparison.compose.yml
+  -h, --help         Show this help message
+EOF
+}
+
+comparison=false
+command=""
+
+while (($# > 0)); do
+    case "$1" in
+        -c|--comparison)
+            comparison=true
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        start|stop|clean)
+            if [[ -n "$command" ]]; then
+                echo "Only one command is allowed: start, stop, or clean." >&2
+                usage >&2
+                exit 1
+            fi
+            command="$1"
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+if [[ -z "$command" ]]; then
+    echo "Missing command: start, stop, or clean." >&2
+    usage >&2
+    exit 1
+fi
+
+compose_args=()
+if $comparison; then
+    compose_args=(-f comparison.compose.yml)
+fi
+
+export GRAFANA_USER_PWD="${GRAFANA_USER_PWD:-supersafepassword}"
+export ADMIN_PWD="${ADMIN_PWD:-evensaferpassword}"
+
+case "$command" in
+    start)
+        if [[ ! -s "db-config/cedar/license.env" ]]; then
+            echo "Missing required Cedar license file: db-config/cedar/license.env" >&2
+            exit 1
+        fi
+        docker compose "${compose_args[@]}" up -d --build --force-recreate
+        ;;
+    stop)
+        docker compose "${compose_args[@]}" down
+        ;;
+    clean)
+        docker compose "${compose_args[@]}" down -v
+        ;;
+esac

--- a/nasdaq/grafana/datasources/automatic.yml
+++ b/nasdaq/grafana/datasources/automatic.yml
@@ -13,11 +13,11 @@ datasources:
     uid: fdl2zuq913klcb
     orgId: 1
     url: cedar:5432
-    user: postgres
+    user: grafana
     database: postgres
     basicAuth: false
     secureJsonData:
-      password: postgres
+      password: ${GRAFANA_USER_PWD}
     isDefault: true
     jsonData:
       connMaxLifetime: 14400
@@ -36,11 +36,11 @@ datasources:
     uid: fdl2zuq913klcc
     orgId: 1
     url: postgres:5432
-    user: postgres
+    user: grafana
     database: postgres
     basicAuth: false
     secureJsonData:
-      password: postgres
+      password: ${GRAFANA_USER_PWD}
     isDefault: false
     jsonData:
       connMaxLifetime: 14400

--- a/nasdaq/grafana/datasources/automatic.yml
+++ b/nasdaq/grafana/datasources/automatic.yml
@@ -13,7 +13,7 @@ datasources:
     uid: fdl2zuq913klcb
     orgId: 1
     url: cedar:5432
-    user: grafana
+    user: ${GRAFANA_USER}
     database: postgres
     basicAuth: false
     secureJsonData:
@@ -36,7 +36,7 @@ datasources:
     uid: fdl2zuq913klcc
     orgId: 1
     url: postgres:5432
-    user: grafana
+    user: ${GRAFANA_USER}
     database: postgres
     basicAuth: false
     secureJsonData:


### PR DESCRIPTION
- at db init a new grafana user is created
- while creating the nasdaq schema we grant select to the grafana user
- a demo.sh script handles the start and stop of the docker compose deployment. it checks for a cedar license to be present. 